### PR TITLE
Feature/no costs on invoice

### DIFF
--- a/Model/Total/Invoice/Tax/BuckarooFee.php
+++ b/Model/Total/Invoice/Tax/BuckarooFee.php
@@ -50,28 +50,14 @@ class BuckarooFee extends \Magento\Sales\Model\Order\Invoice\Total\AbstractTotal
     {
         $order = $invoice->getOrder();
 
-        /**
-         * @noinspection PhpUndefinedMethodInspection
-         */
         $buckarooFeeTaxAmountLeft = $order->getBuckarooFeeTaxAmount() - $order->getBuckarooFeeTaxAmountInvoiced();
-        /**
-         * @noinspection PhpUndefinedMethodInspection
-         */
         $baseBuckarooFeeTaxAmountLeft = $order->getBuckarooFeeBaseTaxAmount()
             - $order->getBuckarooFeeBaseTaxAmountInvoiced();
-        /**
-         * @noinspection PhpUndefinedMethodInspection
-         */
+
         $buckarooFeeInclTaxAmountLeft = $order->getBuckarooFeeInclTax() - $order->getBuckarooFeeTaxInvoiced();
-        /**
-         * @noinspection PhpUndefinedMethodInspection
-         */
         $baseBuckarooFeeInclTaxAmountLeft = $order->getBaseBuckarooFeeInclTax()
             - $order->getBaseBuckarooFeeInclTaxInvoiced();
 
-        /**
-         * @noinspection PhpUndefinedMethodInspection
-         */
         if ($order->getBuckarooFeeBaseTaxAmount() && $baseBuckarooFeeTaxAmountLeft > 0) {
             if ($baseBuckarooFeeTaxAmountLeft < $invoice->getBaseGrandTotal()) {
                 $invoice->setGrandTotal($invoice->getGrandTotal() + $buckarooFeeTaxAmountLeft);

--- a/Model/Total/Invoice/Tax/BuckarooFee.php
+++ b/Model/Total/Invoice/Tax/BuckarooFee.php
@@ -59,6 +59,15 @@ class BuckarooFee extends \Magento\Sales\Model\Order\Invoice\Total\AbstractTotal
          */
         $baseBuckarooFeeTaxAmountLeft = $order->getBuckarooFeeBaseTaxAmount()
             - $order->getBuckarooFeeBaseTaxAmountInvoiced();
+        /**
+         * @noinspection PhpUndefinedMethodInspection
+         */
+        $buckarooFeeInclTaxAmountLeft = $order->getBuckarooFeeInclTax() - $order->getBuckarooFeeTaxInvoiced();
+        /**
+         * @noinspection PhpUndefinedMethodInspection
+         */
+        $baseBuckarooFeeInclTaxAmountLeft = $order->getBaseBuckarooFeeInclTax()
+            - $order->getBaseBuckarooFeeInclTaxInvoiced();
 
         /**
          * @noinspection PhpUndefinedMethodInspection
@@ -86,6 +95,14 @@ class BuckarooFee extends \Magento\Sales\Model\Order\Invoice\Total\AbstractTotal
              * @noinspection PhpUndefinedMethodInspection
              */
             $invoice->setBuckarooFeeBaseTaxAmount($baseBuckarooFeeTaxAmountLeft);
+            /**
+             * @noinspection PhpUndefinedMethodInspection
+             */
+            $invoice->setBuckarooFeeInclTax($buckarooFeeInclTaxAmountLeft);
+            /**
+             * @noinspection PhpUndefinedMethodInspection
+             */
+            $invoice->setBaseBuckarooFeeInclTax($baseBuckarooFeeInclTaxAmountLeft);
         }
 
         return $this;

--- a/Model/Total/Invoice/Tax/BuckarooFee.php
+++ b/Model/Total/Invoice/Tax/BuckarooFee.php
@@ -87,21 +87,10 @@ class BuckarooFee extends \Magento\Sales\Model\Order\Invoice\Total\AbstractTotal
             $invoice->setTaxAmount($invoice->getTaxAmount() + $buckarooFeeTaxAmountLeft);
             $invoice->setBaseTaxAmount($invoice->getBaseTaxAmount() + $baseBuckarooFeeTaxAmountLeft);
 
-            /**
-             * @noinspection PhpUndefinedMethodInspection
-             */
             $invoice->setBuckarooFeeTaxAmount($buckarooFeeTaxAmountLeft);
-            /**
-             * @noinspection PhpUndefinedMethodInspection
-             */
             $invoice->setBuckarooFeeBaseTaxAmount($baseBuckarooFeeTaxAmountLeft);
-            /**
-             * @noinspection PhpUndefinedMethodInspection
-             */
+
             $invoice->setBuckarooFeeInclTax($buckarooFeeInclTaxAmountLeft);
-            /**
-             * @noinspection PhpUndefinedMethodInspection
-             */
             $invoice->setBaseBuckarooFeeInclTax($baseBuckarooFeeInclTaxAmountLeft);
         }
 

--- a/Setup/UpgradeData.php
+++ b/Setup/UpgradeData.php
@@ -977,22 +977,15 @@ class UpgradeData implements \Magento\Framework\Setup\UpgradeDataInterface
      */
     protected function addInclTaxColumns(ModuleDataSetupInterface $setup)
     {
-        /**
-         * @noinspection PhpUndefinedMethodInspection
-         */
+
         $salesInstaller = $this->salesSetupFactory->create(['resourceName' => 'sales_setup', 'setup' => $setup]);
 
-        /**
-         * @noinspection PhpUndefinedMethodInspection
-         */
         $salesInstaller->addAttribute(
             'invoice',
             'base_buckaroo_fee_incl_tax',
             ['type' => \Magento\Framework\DB\Ddl\Table::TYPE_DECIMAL]
         );
-        /**
-         * @noinspection PhpUndefinedMethodInspection
-         */
+
         $salesInstaller->addAttribute(
             'invoice',
             'buckaroo_fee_incl_tax',

--- a/Setup/UpgradeData.php
+++ b/Setup/UpgradeData.php
@@ -479,6 +479,10 @@ class UpgradeData implements \Magento\Framework\Setup\UpgradeDataInterface
         if (version_compare($context->getVersion(), '1.3.0', '<')) {
             $this->installBaseGiftcards($setup, $this->giftcardAdditionalArray);
         }
+
+        if (version_compare($context->getVersion(), '1.4.1', '<')) {
+            $this->addInclTaxColumns($setup);
+        }
     }
 
     /**
@@ -962,5 +966,37 @@ class UpgradeData implements \Magento\Framework\Setup\UpgradeDataInterface
         }
 
         return $this;
+    }
+
+    /**
+     * Adds the Incl tax columns to the invoice table, so they can be used in pdf.xml
+     *
+     * @param ModuleDataSetupInterface $setup
+     *
+     * @return $this
+     */
+    protected function addInclTaxColumns(ModuleDataSetupInterface $setup)
+    {
+        /**
+         * @noinspection PhpUndefinedMethodInspection
+         */
+        $salesInstaller = $this->salesSetupFactory->create(['resourceName' => 'sales_setup', 'setup' => $setup]);
+
+        /**
+         * @noinspection PhpUndefinedMethodInspection
+         */
+        $salesInstaller->addAttribute(
+            'invoice',
+            'base_buckaroo_fee_incl_tax',
+            ['type' => \Magento\Framework\DB\Ddl\Table::TYPE_DECIMAL]
+        );
+        /**
+         * @noinspection PhpUndefinedMethodInspection
+         */
+        $salesInstaller->addAttribute(
+            'invoice',
+            'buckaroo_fee_incl_tax',
+            ['type' => \Magento\Framework\DB\Ddl\Table::TYPE_DECIMAL]
+        );
     }
 }

--- a/Setup/UpgradeData.php
+++ b/Setup/UpgradeData.php
@@ -977,8 +977,13 @@ class UpgradeData implements \Magento\Framework\Setup\UpgradeDataInterface
      */
     protected function addInclTaxColumns(ModuleDataSetupInterface $setup)
     {
-
-        $salesInstaller = $this->salesSetupFactory->create(['resourceName' => 'sales_setup', 'setup' => $setup]);
+        /**
+         * @var \Magento\Sales\Setup\SalesSetup $salesInstaller
+         */
+        $salesInstaller = $this->salesSetupFactory->create([
+            'resourceName' => 'sales_setup',
+            'setup' => $setup
+        ]);
 
         $salesInstaller->addAttribute(
             'invoice',

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -27,7 +27,7 @@
  */
  -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:TIG_Buckaroo:etc/tig_module.xsd">
-    <module name="TIG_Buckaroo" setup_version="1.4.0" build_number="1214" stability="stable">
+    <module name="TIG_Buckaroo" setup_version="1.4.1" build_number="1214" stability="stable">
         <sequence>
             <module name="Magento_Payment"/>
         </sequence>

--- a/etc/pdf.xml
+++ b/etc/pdf.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Sales:etc/pdf_file.xsd">
+    <totals>
+        <total name="buckaroo_fee">
+            <title translate="true">Payment fee</title>
+            <source_field>buckaroo_fee_incl_tax</source_field>
+            <font_size>7</font_size>
+            <display_zero>false</display_zero>
+            <sort_order>450</sort_order>
+        </total>
+    </totals>
+</config>


### PR DESCRIPTION
**Problem**
The problem that this branch solves is that it adds the Buckaroo fee to the PDF that is being generated for an invoice. This is a requirement to make the invoice valid by dutch law.

**Changes**
- Updated the module.xml setup_version, because the upgradedata changed.
- Added pdf.xml, this is a requirement for the invoice generation.
- Added the including tax calculation to the invoice fee, so it can be stored in the database.
- Added the including tax fees to the UpgradeData for the invoice table, this way they can be called from the pdf.xml schema.