### PR TITLE
Set layout fo checkout index index to checkout

### DIFF
--- a/view/frontend/layout/checkout_index_index.xml
+++ b/view/frontend/layout/checkout_index_index.xml
@@ -38,7 +38,7 @@
  * @license     http://creativecommons.org/licenses/by-nc-nd/3.0/nl/deed.en_US
  */
  -->
-<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="1column" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="checkout" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <head>
         <css src="TIG_Buckaroo::css/styles.css" />
     </head>


### PR DESCRIPTION
- [x] I've **verified** and **I assure** that I'm running the latest version of the TIG Buckaroo Magento extension.

---

### What is the purpose of your *issue*?
- [x] Bug report (encountered problems with the TIG Buckaroo Magento extension)
- [ ] Site support request (request for adding support for a new site)
- [ ] Feature request (request for a new functionality)
- [ ] Question
- [ ] Other

---

### Description

By default the layout for the checkout is set to "checkout". But the Buckaroo extension overwrites this to "1column". This results in a different header then expected. In the "1column" header is the search block, mini cart, welcome message and account links. But in the header of the "checkout" layout there's only a logo. Please keep this standard Magento.

Header of layout "1column"
![screen shot 2017-12-05 at 11 39 15](https://user-images.githubusercontent.com/9214557/33602893-087c3464-d9b1-11e7-87fa-94955bed78b7.png)

Header of layout "checkout"
![screen shot 2017-12-05 at 11 39 35](https://user-images.githubusercontent.com/9214557/33602907-0d4502c8-d9b1-11e7-96d3-b032c33bf11a.png)