### PR TITLE
Bugfix Magento 2.2 Set Payment Information returning 400 error.

### DIFF
--- a/Model/Checkout/Plugin/GuestValidation.php
+++ b/Model/Checkout/Plugin/GuestValidation.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ *                  ___________       __            __
+ *                  \__    ___/____ _/  |_ _____   |  |
+ *                    |    |  /  _ \\   __\\__  \  |  |
+ *                    |    | |  |_| ||  |   / __ \_|  |__
+ *                    |____|  \____/ |__|  (____  /|____/
+ *                                              \/
+ *          ___          __                                   __
+ *         |   |  ____ _/  |_   ____ _______   ____    ____ _/  |_
+ *         |   | /    \\   __\_/ __ \\_  __ \ /    \ _/ __ \\   __\
+ *         |   ||   |  \|  |  \  ___/ |  | \/|   |  \\  ___/ |  |
+ *         |___||___|  /|__|   \_____>|__|   |___|  / \_____>|__|
+ *                  \/                           \/
+ *                  ________
+ *                 /  _____/_______   ____   __ __ ______
+ *                /   \  ___\_  __ \ /  _ \ |  |  \\____ \
+ *                \    \_\  \|  | \/|  |_| ||  |  /|  |_| |
+ *                 \______  /|__|    \____/ |____/ |   __/
+ *                        \/                       |__|
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Creative Commons License.
+ * It is available through the world-wide-web at this URL:
+ * http://creativecommons.org/licenses/by-nc-nd/3.0/nl/deed.en_US
+ * If you are unable to obtain it through the world-wide-web, please send an email
+ * to servicedesk@totalinternetgroup.nl so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade this module to newer
+ * versions in the future. If you wish to customize this module for your
+ * needs please contact servicedesk@totalinternetgroup.nl for more information.
+ *
+ * @copyright Copyright (c) 2016 Total Internet Group B.V. (http://www.totalinternetgroup.nl)
+ * @license   http://creativecommons.org/licenses/by-nc-nd/3.0/nl/deed.en_US
+ */
+namespace TIG\Buckaroo\Model\Checkout\Plugin;
+
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\CheckoutAgreements\Api\CheckoutAgreementsRepositoryInterface;
+use Magento\Checkout\Api\AgreementsValidatorInterface;
+use Magento\Checkout\Api\GuestPaymentInformationManagementInterface;
+use Magento\Quote\Api\Data\PaymentInterface;
+use Magento\Quote\Api\Data\AddressInterface;
+use Magento\CheckoutAgreements\Model\Checkout\Plugin\GuestValidation as MagentoValidation;
+
+/**
+ * Class GuestValidation
+ *
+ * Need to override the beforeSavePaymentInformation function and leave it empty.
+ * This is because on setting the payment information for Buckaroo, a request is made to update the information.
+ * In this update the check is applied before the user can even click on the accept terms and conditions checkbox.
+ * If the function is left empty, this check is skipped and the totals get updated correctly.
+ */
+class GuestValidation extends MagentoValidation
+{
+    /**
+     * @var ScopeConfigInterface
+     */
+    private $scopeConfiguration;
+
+    /**
+     * @var CheckoutAgreementsRepositoryInterface
+     */
+    private $checkoutAgreementsRepository;
+
+    /**
+     * @var AgreementsValidatorInterface
+     */
+    private $agreementsValidator;
+
+    /**
+     * @param AgreementsValidatorInterface $agreementsValidator
+     * @param ScopeConfigInterface $scopeConfiguration
+     * @param CheckoutAgreementsRepositoryInterface $checkoutAgreementsRepository
+     */
+    public function __construct(
+        AgreementsValidatorInterface $agreementsValidator,
+        ScopeConfigInterface $scopeConfiguration,
+        CheckoutAgreementsRepositoryInterface $checkoutAgreementsRepository
+    ) {
+        $this->agreementsValidator = $agreementsValidator;
+        $this->scopeConfiguration = $scopeConfiguration;
+        $this->checkoutAgreementsRepository = $checkoutAgreementsRepository;
+    }
+
+    /**
+     * @param GuestPaymentInformationManagementInterface $subject
+     * @param string $cartId
+     * @param string $email
+     * @param PaymentInterface $paymentMethod
+     * @param AddressInterface|null $billingAddress
+     *
+     * @return void
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    public function beforeSavePaymentInformation(
+        GuestPaymentInformationManagementInterface $subject,
+        $cartId,
+        $email,
+        PaymentInterface $paymentMethod,
+        AddressInterface $billingAddress = null
+    ) {
+    }
+}

--- a/Model/Checkout/Plugin/Validation.php
+++ b/Model/Checkout/Plugin/Validation.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ *                  ___________       __            __
+ *                  \__    ___/____ _/  |_ _____   |  |
+ *                    |    |  /  _ \\   __\\__  \  |  |
+ *                    |    | |  |_| ||  |   / __ \_|  |__
+ *                    |____|  \____/ |__|  (____  /|____/
+ *                                              \/
+ *          ___          __                                   __
+ *         |   |  ____ _/  |_   ____ _______   ____    ____ _/  |_
+ *         |   | /    \\   __\_/ __ \\_  __ \ /    \ _/ __ \\   __\
+ *         |   ||   |  \|  |  \  ___/ |  | \/|   |  \\  ___/ |  |
+ *         |___||___|  /|__|   \_____>|__|   |___|  / \_____>|__|
+ *                  \/                           \/
+ *                  ________
+ *                 /  _____/_______   ____   __ __ ______
+ *                /   \  ___\_  __ \ /  _ \ |  |  \\____ \
+ *                \    \_\  \|  | \/|  |_| ||  |  /|  |_| |
+ *                 \______  /|__|    \____/ |____/ |   __/
+ *                        \/                       |__|
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Creative Commons License.
+ * It is available through the world-wide-web at this URL:
+ * http://creativecommons.org/licenses/by-nc-nd/3.0/nl/deed.en_US
+ * If you are unable to obtain it through the world-wide-web, please send an email
+ * to servicedesk@totalinternetgroup.nl so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade this module to newer
+ * versions in the future. If you wish to customize this module for your
+ * needs please contact servicedesk@totalinternetgroup.nl for more information.
+ *
+ * @copyright Copyright (c) 2016 Total Internet Group B.V. (http://www.totalinternetgroup.nl)
+ * @license   http://creativecommons.org/licenses/by-nc-nd/3.0/nl/deed.en_US
+ */
+namespace TIG\Buckaroo\Model\Checkout\Plugin;
+
+use Magento\Checkout\Api\AgreementsValidatorInterface;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\CheckoutAgreements\Api\CheckoutAgreementsRepositoryInterface;
+use Magento\Checkout\Api\PaymentInformationManagementInterface;
+use Magento\Quote\Api\Data\PaymentInterface;
+use Magento\Quote\Api\Data\AddressInterface;
+use Magento\CheckoutAgreements\Model\Checkout\Plugin\Validation as MagentoValidation;
+
+/**
+ * Class Validation
+ */
+class Validation extends MagentoValidation
+{
+    /**
+     * @var ScopeConfigInterface
+     */
+    protected $scopeConfiguration;
+
+    /**
+     * @var CheckoutAgreementsRepositoryInterface
+     */
+    protected $checkoutAgreementsRepository;
+
+    /**
+     * @var AgreementsValidatorInterface
+     */
+    protected $agreementsValidator;
+
+    /**
+     * @param AgreementsValidatorInterface $agreementsValidator
+     * @param ScopeConfigInterface $scopeConfiguration
+     * @param CheckoutAgreementsRepositoryInterface $checkoutAgreementsRepository
+     */
+    public function __construct(
+        AgreementsValidatorInterface $agreementsValidator,
+        ScopeConfigInterface $scopeConfiguration,
+        CheckoutAgreementsRepositoryInterface $checkoutAgreementsRepository
+    ) {
+        $this->agreementsValidator = $agreementsValidator;
+        $this->scopeConfiguration = $scopeConfiguration;
+        $this->checkoutAgreementsRepository = $checkoutAgreementsRepository;
+    }
+
+    /**
+     * @param PaymentInformationManagementInterface $subject
+     * @param int $cartId
+     * @param PaymentInterface $paymentMethod
+     * @param AddressInterface|null $billingAddress
+     * @return void
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    public function beforeSavePaymentInformation(
+        PaymentInformationManagementInterface $subject,
+        $cartId,
+        PaymentInterface $paymentMethod,
+        AddressInterface $billingAddress = null
+    ) {
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,8 @@
     "require": {
         "php": "~5.5.0|~5.6.0|~7.0.0",
         "magento/module-payment": "100.0.*|100.1.*|100.2.*",
-        "magento/framework": ">=100.0.10,<=100.0.19|>=100.1.0,<=100.1.11|>=101.0.0,<=101.0.2"
+        "magento/framework": ">=100.0.10,<=100.0.19|>=100.1.0,<=100.1.11|>=101.0.0,<=101.0.2",
+        "magento/module-checkout-agreements": "100.2.*"
     },
     "type": "magento2-module",
     "license": "CC-BY-NC-ND-3.0",

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -47,6 +47,8 @@
     <preference for="TIG\Buckaroo\Api\PaymentInformationManagementInterface" type="TIG\Buckaroo\Model\PaymentInformationManagement"/>
     <preference for="TIG\Buckaroo\Api\GuestPaymentInformationManagementInterface" type="TIG\Buckaroo\Model\GuestPaymentInformationManagement"/>
     <preference for="Magento\Quote\Model\Cart\CartTotalRepository" type="TIG\Buckaroo\Model\Cart\CartTotalRepository" />
+    <preference for="Magento\CheckoutAgreements\Model\Checkout\Plugin\Validation" type="TIG\Buckaroo\Model\Checkout\Plugin\Validation" />
+    <preference for="Magento\CheckoutAgreements\Model\Checkout\Plugin\GuestValidation" type="TIG\Buckaroo\Model\Checkout\Plugin\GuestValidation" />
 
     <type name="TIG\Buckaroo\Model\Method\AbstractMethod">
         <arguments>


### PR DESCRIPTION
### Submitting issues trough Github
## Please follow the guide below

- You will be asked some questions and requested to provide some information, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *issue* (like this: `[x]`)
- Use the *Preview* tab to see what your issue will actually look like

---

### Make sure you are using the *latest* version: https://tig.nl/buckaroo-magento-extensies/
Issues with outdated version will be rejected.
- [x] I've **verified** and **I assure** that I'm running the latest version of the TIG Buckaroo Magento extension.

---

### What is the purpose of your *issue*?
- [x] Bug report (encountered problems with the TIG Buckaroo Magento extension)
- [ ] Site support request (request for adding support for a new site)
- [ ] Feature request (request for a new functionality)
- [ ] Question
- [ ] Other

---

### Description of your *issue*, suggested solution and other information

The reason for this change is that the checkout is blocked when Agreements should be accepted.
Buckaroo actively updates the payment information in the checkout summary, which comes across this check and thus gets blocked when checkout agreements are required.

With this update the Agreements Validation that is called on setting the payment information (which seems to be unneccesary from Magento's side) gets ignored.
This is done through the use of a preference.

### TIG supportdesk

On Github we will respond in English even when the question was asked in Dutch.
