### PR TITLE
Send email only if $statusCode is TIG_BUCKAROO_STATUSCODE_SUCCESS (190)

### DIFF
--- a/Controller/Redirect/Process.php
+++ b/Controller/Redirect/Process.php
@@ -188,10 +188,10 @@ class Process extends \Magento\Framework\App\Action\Action
                 /**
                  * @noinspection PhpUndefinedMethodInspection
                  */
-                if (!$this->order->getEmailSent()
-                    && ($this->accountConfig->getOrderConfirmationEmail($store) === "1"
-                        || $paymentMethod->getConfigData('order_email', $store) === "1"
-                    )
+                if (!$this->order->getEmailSent() &&
+                    ($this->accountConfig->getOrderConfirmationEmail($store) === "1" ||
+                        $paymentMethod->getConfigData('order_email', $store) === "1") &&
+                    $statusCode === $this->helper->getStatusCode('TIG_BUCKAROO_STATUSCODE_SUCCESS')
                 ) {
                     $this->orderSender->send($this->order, true);
                 }


### PR DESCRIPTION
### What is the purpose of your *issue*?
- [ ] Bug report (encountered problems with the TIG Buckaroo Magento extension)
- [ ] Site support request (request for adding support for a new site)
- [ ] Feature request (request for a new functionality)
- [ ] Question
- [ x ] Other

---

### Description of your *issue*, suggested solution and other information

Improvement: send email only $statusCode is TIG_BUCKAROO_STATUSCODE_SUCCESS (190)
