### PR TITLE
RC version for Magento 2.2.10/2.3.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "require": {
         "php": "~5.6.0|~7.0.0|~7.1.0|~7.2.0",
         "magento/module-payment": "100.1.*|100.2.*|100.3.*",
-        "magento/framework": ">=100.1.0,<=100.1.18|>=101.0.0,<=101.0.9|>=102.0.0,<=102.0.2"
+        "magento/framework": ">=100.1.0,<=100.1.18|>=101.0.0,<=101.0.10|>=102.0.0,<=102.0.3"
     },
     "type": "magento2-module",
     "license": "CC-BY-NC-ND-3.0",
@@ -22,8 +22,8 @@
         "docs": "http://servicedesk.tig.nl/hc/nl/articles/218518187-EN-Buckaroo-Magento-2-Installation-and-Configuration-manual"
     },
     "homepage": "https://store.tig.nl/buckaroo.html",
-    "version" : "v1.12.0",
-    "minimum-stability": "stable",
+    "version" : "v1.13.0-RC1",
+    "minimum-stability": "RC",
     "autoload": {
         "files": [
             "registration.php"

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -27,7 +27,7 @@
  */
  -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:TIG_Buckaroo:etc/tig_module.xsd">
-    <module name="TIG_Buckaroo" setup_version="1.10.0" build_number="1762" stability="stable">
+    <module name="TIG_Buckaroo" setup_version="1.10.0" build_number="1762" stability="rc">
         <sequence>
             <module name="Magento_Payment"/>
         </sequence>


### PR DESCRIPTION
- [ ] Bug report (encountered problems with the TIG Buckaroo Magento extension)
- [ ] Site support request (request for adding support for a new site)
- [ ] Feature request (request for a new functionality)
- [ ] Question
- [x] Other

Description

TIG Buckaroo has an hard requirement on Magento version 2.3.2 or less. In order to update to Magento 2.3.3 we need to change the requirements.
