### PR TITLE
Fix the configProvider for methods with a plugin

### DIFF
--- a/Model/ConfigProvider/AbstractConfigProvider.php
+++ b/Model/ConfigProvider/AbstractConfigProvider.php
@@ -120,6 +120,10 @@ abstract class AbstractConfigProvider implements ConfigProviderInterface
             $class = get_class($this);
             $classParts = explode('\\', $class);
             $className = end($classParts);
+            if ($className == 'Interceptor') {
+                array_pop($classParts);
+                $className = end($classParts);
+            }
 
             /**
              * Uppercase and append it to the XPATH prefix & child class' name


### PR DESCRIPTION
## Problem
I had to re-order the issuers for the iDeal method, so I created a plugin for that. After this change, `getActive()` returned false for iDeal and the payment failed with a critical message in the log: _Cannot do a Buckaroo transaction when 'mode' is not set or set to 0._ .

## Cause
Because the `AbstractConfigProvider` tries to compose a constant name based on the last part of a classname, it tried to look for `\TIG\Buckaroo\Model\ConfigProvider\Method\Ideal\Interceptor::XPATH_INTERCEPTOR_ACTIVE`. This constant, of course, does not exist.

## Solution
If the last part of the class name is 'Interceptor', pop the last item off the array and use the second last part. I cannot think of any side effects of this change.